### PR TITLE
#412322 Persist files as a batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ npm run
 
 ## API endpoints
 
-| Endpoint              | Description                                                                                     |
-| :-------------------- | :---------------------------------------------------------------------------------------------- |
-| `GET: /health`        | Health                                                                                          |
-| `POST: /file`         | Ingests a file with a 7 day expiry. Called by the CDP uploader as a callback (upon file upload) |
-| `GET: /file/{fileId}` | Checks that a file has been ingested.                                                           |
-| `POST: /file/link`    | Creates a link to a file which can be accessed by a user. Valid for 60 minutes.                 |
-| `POST: /file/persist` | Extends the expiry to 30 days. Called upon form submission.                                     |
+| Endpoint               | Description                                                                                     |
+| :--------------------- | :---------------------------------------------------------------------------------------------- |
+| `GET: /health`         | Health                                                                                          |
+| `POST: /file`          | Ingests a file with a 7 day expiry. Called by the CDP uploader as a callback (upon file upload) |
+| `GET: /file/{fileId}`  | Checks that a file has been ingested.                                                           |
+| `POST: /file/link`     | Creates a link to a file which can be accessed by a user. Valid for 60 minutes.                 |
+| `POST: /files/persist` | Extends the expiry to 30 days. Called upon form submission.                                     |
 
 ## Docker
 

--- a/docs/ingesting-a-file.md
+++ b/docs/ingesting-a-file.md
@@ -45,15 +45,15 @@ key as this value may have been updated between the form's file upload and form 
 ```json
 {
   "files": [
-		{
-			"fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b18",
-			"initiatedRetrievalKey": "the-retrieval-key-for-this-file"
-		},
-		{
-			"fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b19",
-			"initiatedRetrievalKey": "perhaps-a-different-retrieval-key"
-		}
-	],
-	"persistedRetrievalKey": "a-new-key-applied-to-all-files-in-the-batch"
+    {
+      "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b18",
+      "initiatedRetrievalKey": "the-retrieval-key-for-this-file"
+    },
+    {
+      "fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b19",
+      "initiatedRetrievalKey": "perhaps-a-different-retrieval-key"
+    }
+  ],
+  "persistedRetrievalKey": "a-new-key-applied-to-all-files-in-the-batch"
 }
 ```

--- a/docs/ingesting-a-file.md
+++ b/docs/ingesting-a-file.md
@@ -32,10 +32,10 @@ For more information, see:
 - [S3 configuration](https://github.com/DEFRA/cdp-tf-svc-infra/blob/307bc350ab1baf5cd8ad9d2cdaaf9693cd9610de/environments/prod/resources/s3_bucket_names.json#L33)
 
 cdp-uploader will upload the files with a prefix of `staging/`, which per the above link has a 7 day expiry. Upon form submission,
-all files within the form submission need to be accessible for 30 days. `forms-runner` would then call the `POST /file/persist`
+all files within the form submission need to be accessible for 30 days. `forms-runner` would then call the `POST /files/persist`
 for each file to load it into the `/loaded` directory which has a 30 day expiry on it.
 
 ## Persisting a file for 30 days
 
-In addition to `POST /file/persist` moving the file into the prefix with a 30 day expiry, the endpoint takes an updated retrieval
+In addition to `POST /files/persist` moving the file into the prefix with a 30 day expiry, the endpoint takes an updated retrieval
 key as this value may have been updated between the form's file upload and form submission.

--- a/docs/ingesting-a-file.md
+++ b/docs/ingesting-a-file.md
@@ -33,9 +33,27 @@ For more information, see:
 
 cdp-uploader will upload the files with a prefix of `staging/`, which per the above link has a 7 day expiry. Upon form submission,
 all files within the form submission need to be accessible for 30 days. `forms-runner` would then call the `POST /files/persist`
-for each file to load it into the `/loaded` directory which has a 30 day expiry on it.
+with each file to load it into the `/loaded` directory which has a 30 day expiry on it.
 
 ## Persisting a file for 30 days
 
-In addition to `POST /files/persist` moving the file into the prefix with a 30 day expiry, the endpoint takes an updated retrieval
+In addition to `POST /files/persist` moving files into the prefix with a 30 day expiry, the endpoint takes an updated retrieval
 key as this value may have been updated between the form's file upload and form submission.
+
+`/files/persist` is designed to be called on form submission, so it can take a batch of files to update in one transaction. For example:
+
+```json
+{
+  "files": [
+		{
+			"fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b18",
+			"initiatedRetrievalKey": "the-retrieval-key-for-this-file"
+		},
+		{
+			"fileId": "9fcaabe5-77ec-44db-8356-3a6e8dc51b19",
+			"initiatedRetrievalKey": "perhaps-a-different-retrieval-key"
+		}
+	],
+	"persistedRetrievalKey": "a-new-key-applied-to-all-files-in-the-batch"
+}
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,7 +9,7 @@ See https://dev.azure.com/defragovuk/DEFRA-CDP/_wiki/wikis/Digital%20Forms%20Acc
 forms-runner
 
 1. A call to `POST /file` is made via cdp-uploader to ingest the file into the database.
-2. After some time, the user submits the form. A call to `/file/persist` is made to extend the expiry time.
+2. After some time, the user submits the form. A call to `/files/persist` is made to extend the expiry time.
 3. A download link is sent to the internal user, but this link is NOT the result of `POST /file/link` but a permanent
    download page in forms-designer that allows the user to input the retrieval key.
 

--- a/src/api/files/repository.js
+++ b/src/api/files/repository.js
@@ -82,7 +82,7 @@ async function updateField(fileIds, fieldName, fieldValue, session) {
     { session }
   )
 
-  if (result.modifiedCount !== 1) {
+  if (!result.acknowledged) {
     throw new Error(`Failed to update ${fieldName}`)
   }
 

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -102,11 +102,25 @@ export async function getPresignedLink(fileId, retrievalKey) {
 
 /**
  * Extends the time-to-live of a file to 30 days and updates the retrieval key.
+ * @param {{fileId: string, initiatedRetrievalKey: string}[]} files
+ * @param {string} persistedRetrievalKey - an updated retrieval key to persist the file
+ */
+export async function persistFiles(files, persistedRetrievalKey) {
+  const persistOperations = files.map(
+    async ({ fileId, initiatedRetrievalKey }) =>
+      persistFile(fileId, initiatedRetrievalKey, persistedRetrievalKey)
+  )
+
+  await Promise.all(persistOperations)
+}
+
+/**
+ * Extends the time-to-live of a file to 30 days and updates the retrieval key.
  * @param {string} fileId
  * @param {string} initiatedRetrievalKey - retrieval key when initiated
  * @param {string} persistedRetrievalKey - an updated retrieval key to persist the file
  */
-export async function persistFile(
+async function persistFile(
   fileId,
   initiatedRetrievalKey,
   persistedRetrievalKey

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -119,8 +119,12 @@ export async function persistFiles(files, persistedRetrievalKey) {
   try {
     await session.withTransaction(async () => {
       logger.info(`Persisting ${files.length} files`)
+      const fileIds = []
+
       // Copy all the source files to the destination
       for (const { fileId, initiatedRetrievalKey } of files) {
+        fileIds.push(fileId)
+
         updateFiles.push(
           // Mongo doesn't support parallel transactions, so we have to await each one
           // Copy each file and update the path in the database
@@ -129,7 +133,6 @@ export async function persistFiles(files, persistedRetrievalKey) {
       }
 
       // Once we know the files have copied successfully, we can update the database
-      const fileIds = files.map(({ fileId }) => fileId)
       const persistedRetrievalKeyHashed = await argon2.hash(
         persistedRetrievalKey
       )

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -230,7 +230,7 @@ async function copyFile(fileId, initiatedRetrievalKey, session, client) {
     )
   } catch (err) {
     if (err instanceof NoSuchKey) {
-      throw Boom.resourceGone()
+      throw Boom.resourceGone(`File ${fileId} no longer exists`)
     }
 
     throw err
@@ -263,7 +263,7 @@ async function getAndVerify(fileId, retrievalKey) {
   )
 
   if (!retrievalKeyCorrect) {
-    throw Boom.forbidden('Retrieval key does not match')
+    throw Boom.forbidden(`Retrieval key for file ${fileId} is incorrect`)
   }
 
   return fileStatus

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -169,10 +169,6 @@ export async function persistFiles(files, persistedRetrievalKey) {
  * @param {S3Client} client - S3 client
  */
 async function deleteOldFiles(keys, lookupKey, client) {
-  // Only delete the old files once the pointer update has succeeded. Handle this outside of the DB session as we don't
-  // want a failure here to revert our DB changes. If this fails, files will naturally expire in the original directory after 7 days
-  // anyway, so this ultimately is just a cost issue not a functional one.
-
   // AWS do have the DeleteObjects command instead which would be preferable. However, S3 keys
   // are stored on a per-document basis not a global and so we can't batch these up in case of any
   // variation.

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -4,7 +4,8 @@ import {
   CopyObjectCommand,
   DeleteObjectCommand,
   HeadObjectCommand,
-  NotFound
+  NotFound,
+  NoSuchKey
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import Boom from '@hapi/boom'
@@ -228,9 +229,11 @@ async function copyFile(fileId, initiatedRetrievalKey, session, client) {
       })
     )
   } catch (err) {
-    if (err instanceof NotFound) {
+    if (err instanceof NoSuchKey) {
       throw Boom.resourceGone()
     }
+
+    throw err
   }
 
   await repository.updateS3Key(fileId, newS3Key, session)

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -121,7 +121,7 @@ export async function persistFiles(files, persistedRetrievalKey) {
       logger.info(`Persisting ${files.length} files`)
 
       updateFiles = files.map(({ fileId, initiatedRetrievalKey }) =>
-        copyS3File(fileId, initiatedRetrievalKey, session, client)
+        copyS3File(fileId, initiatedRetrievalKey, client)
       )
 
       for await (const { fileId, newS3Key } of updateFiles) {
@@ -183,14 +183,14 @@ async function deleteOldFiles(keys, lookupKey, client) {
     )
   )
 }
+
 /**
  * Copies a file document to the loaded S3 directory.
  * @param {string} fileId
  * @param {string} initiatedRetrievalKey - retrieval key when initiated
- * @param {ClientSession} session - mongoDB session
  * @param {S3Client} client - S3 client
  */
-async function copyS3File(fileId, initiatedRetrievalKey, session, client) {
+async function copyS3File(fileId, initiatedRetrievalKey, client) {
   const fileStatus = await getAndVerify(fileId, initiatedRetrievalKey)
 
   if (!fileStatus.s3Key || !fileStatus.s3Bucket) {

--- a/src/api/files/service.test.js
+++ b/src/api/files/service.test.js
@@ -18,7 +18,7 @@ import {
   checkExists,
   ingestFile,
   getPresignedLink,
-  persistFile
+  persistFiles
 } from '~/src/api/files/service.js'
 import { prepareDb } from '~/src/mongo.js'
 import 'aws-sdk-client-mock-jest'
@@ -285,9 +285,13 @@ describe('Files service', () => {
       jest.mocked(hash).mockResolvedValueOnce('newKeyHash')
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
-      await persistFile(
-        dummyData.fileId,
-        dummyData.retrievalKey,
+      await persistFiles(
+        [
+          {
+            fileId: dummyData.fileId,
+            initiatedRetrievalKey: dummyData.retrievalKey
+          }
+        ],
         newRetrievalKey
       )
 
@@ -331,7 +335,15 @@ describe('Files service', () => {
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
       await expect(
-        persistFile(dummyData.fileId, dummyData.retrievalKey, newRetrievalKey)
+        persistFiles(
+          [
+            {
+              fileId: dummyData.fileId,
+              initiatedRetrievalKey: dummyData.retrievalKey
+            }
+          ],
+          newRetrievalKey
+        )
       ).rejects.toThrow(Boom.forbidden('Retrieval key does not match'))
 
       expect(s3Mock).not.toHaveReceivedAnyCommand()
@@ -351,9 +363,13 @@ describe('Files service', () => {
       jest.mocked(verify).mockResolvedValueOnce(true)
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
-      await persistFile(
-        dummyData.fileId,
-        dummyData.retrievalKey,
+      await persistFiles(
+        [
+          {
+            fileId: dummyData.fileId,
+            initiatedRetrievalKey: dummyData.retrievalKey
+          }
+        ],
         dummyData.retrievalKey
       )
 
@@ -387,9 +403,13 @@ describe('Files service', () => {
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
       await expect(
-        persistFile(
-          dummyData.fileId,
-          dummyData.retrievalKey,
+        persistFiles(
+          [
+            {
+              fileId: dummyData.fileId,
+              initiatedRetrievalKey: dummyData.retrievalKey
+            }
+          ],
           dummyData.retrievalKey
         )
       ).rejects.toThrow(
@@ -412,9 +432,13 @@ describe('Files service', () => {
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
       await expect(
-        persistFile(
-          dummyData.fileId,
-          dummyData.retrievalKey,
+        persistFiles(
+          [
+            {
+              fileId: dummyData.fileId,
+              initiatedRetrievalKey: dummyData.retrievalKey
+            }
+          ],
           dummyData.retrievalKey
         )
       ).rejects.toThrow(
@@ -437,7 +461,15 @@ describe('Files service', () => {
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
       await expect(
-        persistFile(dummyData.fileId, dummyData.retrievalKey, newRetrievalKey)
+        persistFiles(
+          [
+            {
+              fileId: dummyData.fileId,
+              initiatedRetrievalKey: dummyData.retrievalKey
+            }
+          ],
+          newRetrievalKey
+        )
       ).rejects.toThrow(
         Boom.internal(
           `S3 key/bucket is missing for file ID ${dummyData.fileId}`
@@ -464,7 +496,15 @@ describe('Files service', () => {
       )
 
       await expect(
-        persistFile(dummyData.fileId, dummyData.retrievalKey, newRetrievalKey)
+        persistFiles(
+          [
+            {
+              fileId: dummyData.fileId,
+              initiatedRetrievalKey: dummyData.retrievalKey
+            }
+          ],
+          newRetrievalKey
+        )
       ).rejects.toThrow(Boom.resourceGone())
     })
   })

--- a/src/api/files/service.test.js
+++ b/src/api/files/service.test.js
@@ -259,8 +259,10 @@ describe('Files service', () => {
       jest.mocked(verify).mockResolvedValueOnce(false)
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
-      await expect(getPresignedLink('123-456-789', 'test')).rejects.toThrow(
-        Boom.forbidden('Retrieval key does not match')
+      await expect(getPresignedLink(dummyData.fileId, 'test')).rejects.toThrow(
+        Boom.forbidden(
+          `Retrieval key for file ${dummyData.fileId} is incorrect`
+        )
       )
     })
   })
@@ -410,7 +412,11 @@ describe('Files service', () => {
           ],
           newRetrievalKey
         )
-      ).rejects.toThrow(Boom.forbidden('Retrieval key does not match'))
+      ).rejects.toThrow(
+        Boom.forbidden(
+          `Retrieval key for file ${dummyData.fileId} is incorrect`
+        )
+      )
 
       expect(s3Mock).not.toHaveReceivedAnyCommand()
       expect(repository.updateRetrievalKeys).not.toHaveBeenCalled()
@@ -572,7 +578,9 @@ describe('Files service', () => {
           ],
           newRetrievalKey
         )
-      ).rejects.toThrow(Boom.resourceGone())
+      ).rejects.toThrow(
+        Boom.resourceGone(`File ${dummyData.fileId} no longer exists`)
+      )
     })
   })
 })

--- a/src/api/files/service.test.js
+++ b/src/api/files/service.test.js
@@ -296,14 +296,16 @@ describe('Files service', () => {
       )
 
       expect(hash).toHaveBeenCalledWith(newRetrievalKey)
-      expect(repository.updateRetrievalKey).toHaveBeenCalledWith(
-        dummyData.fileId,
-        'newKeyHash'
+      expect(repository.updateRetrievalKeys).toHaveBeenCalledWith(
+        [dummyData.fileId],
+        'newKeyHash',
+        expect.any(Object) // the session which we aren't testing
       )
 
       expect(repository.updateS3Key).toHaveBeenCalledWith(
         successfulFile.fileId,
-        expectedNewKey
+        expectedNewKey,
+        expect.any(Object) // the session which we aren't testing
       )
 
       expect(s3Mock).toHaveReceivedCommandWith(CopyObjectCommand, {
@@ -314,7 +316,8 @@ describe('Files service', () => {
 
       expect(repository.updateS3Key).toHaveBeenCalledWith(
         successfulFile.fileId,
-        expectedNewKey
+        expectedNewKey,
+        expect.any(Object) // the session which we aren't testing
       )
 
       expect(s3Mock).toHaveReceivedCommandWith(DeleteObjectCommand, {
@@ -347,7 +350,7 @@ describe('Files service', () => {
       ).rejects.toThrow(Boom.forbidden('Retrieval key does not match'))
 
       expect(s3Mock).not.toHaveReceivedAnyCommand()
-      expect(repository.updateRetrievalKey).not.toHaveBeenCalled()
+      expect(repository.updateRetrievalKeys).not.toHaveBeenCalled()
     })
 
     it('should handle nested input directories', async () => {
@@ -382,7 +385,8 @@ describe('Files service', () => {
 
       expect(repository.updateS3Key).toHaveBeenCalledWith(
         successfulFile.fileId,
-        expectedNewKey
+        expectedNewKey,
+        expect.any(Object) // the session which we aren't testing
       )
 
       expect(s3Mock).toHaveReceivedCommandWith(DeleteObjectCommand, {
@@ -488,7 +492,7 @@ describe('Files service', () => {
       jest.mocked(verify).mockResolvedValueOnce(true)
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
-      s3Mock.on(HeadObjectCommand).rejectsOnce(
+      s3Mock.on(CopyObjectCommand).rejectsOnce(
         new NotFound({
           message: 'Not found',
           $metadata: {}

--- a/src/api/files/service.test.js
+++ b/src/api/files/service.test.js
@@ -3,6 +3,7 @@ import {
   DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
+  NoSuchKey,
   NotFound,
   S3Client
 } from '@aws-sdk/client-s3'
@@ -356,8 +357,8 @@ describe('Files service', () => {
         .resolvesOnce({}) // first file succeeds
         .rejectsOnce(
           // second file is not found so we expect a rollback
-          new NotFound({
-            message: 'Not found',
+          new NoSuchKey({
+            message: 'NoSuchKey',
             $metadata: {}
           })
         )
@@ -555,8 +556,8 @@ describe('Files service', () => {
       jest.mocked(repository.getByFileId).mockResolvedValueOnce(dummyData)
 
       s3Mock.on(CopyObjectCommand).rejectsOnce(
-        new NotFound({
-          message: 'Not found',
+        new NoSuchKey({
+          message: 'NoSuchKey',
           $metadata: {}
         })
       )

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -2,7 +2,7 @@
  * @typedef {Request<{ Server: { db: Db }, Payload: UploadPayload }>} RequestFileCreate
  * @typedef {Request<{ Server: { db: Db }, Params: { fileId: string } }>} RequestFileGet
  * @typedef {Request<{ Server: { db: Db }, Payload: { fileId: string, retrievalKey: string } }>} RequestFileLinkCreate
- * @typedef {Request<{ Server: { db: Db }, Payload: { fileId: string, initiatedRetrievalKey: string, persistedRetrievalKey: string } }>} RequestFilePersist
+ * @typedef {Request<{ Server: { db: Db }, Payload: { files: {fileId: string, initiatedRetrievalKey: string}[], persistedRetrievalKey: string } }>} RequestFilePersist
  */
 
 /**

--- a/src/models/files.js
+++ b/src/models/files.js
@@ -51,8 +51,15 @@ export const fileAccessPayloadSchema = Joi.object()
 
 export const filePersistPayloadSchema = Joi.object()
   .keys({
-    fileId: Joi.string().required(),
-    initiatedRetrievalKey: Joi.string().required(),
+    files: Joi.array()
+      .items(
+        Joi.object({
+          fileId: Joi.string().required(),
+          initiatedRetrievalKey: Joi.string().required()
+        })
+      )
+      .max(1000) // to prevent any malicious users but not any legitimate users
+      .required(),
     persistedRetrievalKey: Joi.string().required()
   })
   .required()

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -94,7 +94,7 @@ export default [
       await persistFiles(files, persistedRetrievalKey)
 
       return {
-        message: 'File persisted'
+        message: 'Files persisted'
       }
     },
     options: {

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -2,7 +2,7 @@ import {
   ingestFile,
   checkExists,
   getPresignedLink,
-  persistFile
+  persistFiles
 } from '~/src/api/files/service.js'
 import {
   fileIngestPayloadSchema,
@@ -83,15 +83,15 @@ export default [
   },
   {
     method: 'POST',
-    path: '/file/persist',
+    path: '/files/persist',
     /**
      * @param {RequestFilePersist} request
      */
     async handler(request) {
       const { payload } = request
-      const { fileId, initiatedRetrievalKey, persistedRetrievalKey } = payload
+      const { files, persistedRetrievalKey } = payload
 
-      await persistFile(fileId, initiatedRetrievalKey, persistedRetrievalKey)
+      await persistFiles(files, persistedRetrievalKey)
 
       return {
         message: 'File persisted'

--- a/src/routes/files.test.js
+++ b/src/routes/files.test.js
@@ -123,7 +123,7 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(StatusCodes.OK)
       expect(response.headers['content-type']).toContain('application/json')
       expect(response.result).toMatchObject({
-        message: 'File persisted'
+        message: 'Files persisted'
       })
     })
   })

--- a/src/routes/files.test.js
+++ b/src/routes/files.test.js
@@ -4,7 +4,7 @@ import {
   ingestFile,
   checkExists,
   getPresignedLink,
-  persistFile
+  persistFiles
 } from '../api/files/service.js'
 
 import { createServer } from '~/src/api/server.js'
@@ -102,16 +102,20 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing POST /file/persist route returns success', async () => {
-      jest.mocked(persistFile).mockResolvedValue()
+    test('Testing POST /files/persist route returns success', async () => {
+      jest.mocked(persistFiles).mockResolvedValue()
 
       const response = await server.inject({
         method: 'POST',
-        url: '/file/persist',
+        url: '/files/persist',
         auth,
         payload: {
-          fileId: '1234',
-          initiatedRetrievalKey: '1234',
+          files: [
+            {
+              fileId: '1234',
+              initiatedRetrievalKey: '1234'
+            }
+          ],
           persistedRetrievalKey: '5678'
         }
       })
@@ -226,13 +230,17 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing POST /file/persist route returns bad request if initiatedRetrievalKey is missing', async () => {
+    test('Testing POST /files/persist route returns bad request if initiatedRetrievalKey is missing', async () => {
       const response = await server.inject({
         method: 'POST',
-        url: '/file/persist',
+        url: '/files/persist',
         auth,
         payload: {
-          fileId: '1234',
+          files: [
+            {
+              fileId: '1234'
+            }
+          ],
           persistedRetrievalKey: '1234'
         }
       })
@@ -240,18 +248,22 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(response.result).toMatchObject({
         error: 'Bad Request',
-        message: '"initiatedRetrievalKey" is required'
+        message: '"files[0].initiatedRetrievalKey" is required'
       })
     })
 
-    test('Testing POST /file/persist route returns bad request if persistedRetrievalKey is missing', async () => {
+    test('Testing POST /files/persist route returns bad request if persistedRetrievalKey is missing', async () => {
       const response = await server.inject({
         method: 'POST',
-        url: '/file/persist',
+        url: '/files/persist',
         auth,
         payload: {
-          fileId: '1234',
-          initiatedRetrievalKey: '1234'
+          files: [
+            {
+              fileId: '1234',
+              initiatedRetrievalKey: '1234'
+            }
+          ]
         }
       })
 
@@ -279,13 +291,17 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing POST /file/persist route returns bad request if file ID is missing', async () => {
+    test('Testing POST /files/persist route returns bad request if file ID is missing', async () => {
       const response = await server.inject({
         method: 'POST',
-        url: '/file/persist',
+        url: '/files/persist',
         auth,
         payload: {
-          initiatedRetrievalKey: '1234',
+          files: [
+            {
+              initiatedRetrievalKey: '1234'
+            }
+          ],
           persistedRetrievalKey: '1234'
         }
       })
@@ -293,7 +309,7 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(response.result).toMatchObject({
         error: 'Bad Request',
-        message: '"fileId" is required'
+        message: '"files[0].fileId" is required'
       })
     })
   })


### PR DESCRIPTION
Rather than trying to re-invent the concept of a transaction on the client-side (forms-runner), I decided to implement DB-level transactions in the persistence API and take a batch of files in. This aligns more closely to the desired usage pattern, rather than forms-runner needing to call this API per file.

In short: we will persist all files for a form submission as a batch. If any file in the batch fails to persist, the entire batch is marked as failed and a rollback will be performed. 

This prevents us getting into a state where some files in a form submission are healthy and some are not. Unpicking that would be a nightmare, so we do it as an all-or-nothing approach instead. If a user has an issue, they'll be contacting us anyway so this will not add any extra time onto form submissions in the event of a failure, but it makes it significantly easier to unpick and resolve. Better to have a consistent view of all files, rather than trying to guess which files succeeded and which failed.

Paired with https://github.com/DEFRA/forms-runner/pull/337.