### PR TITLE
Using mongo bulkWrite

### DIFF
--- a/src/api/files/repository.js
+++ b/src/api/files/repository.js
@@ -49,6 +49,28 @@ export async function updateS3Key(fileId, s3Key, session) {
 }
 
 /**
+ * Updates the S3 Keys for a given set of files
+ * @param {{ fileId: string; s3Bucket: string; oldS3Key: string; newS3Key: string; }[]} updateFiles
+ * @param {ClientSession} session
+ */
+export async function updateS3Keys(updateFiles, session) {
+  const ops = updateFiles.map(({ fileId, newS3Key: s3Key }) => {
+    return {
+      updateOne: {
+        filter: { fileId },
+        update: [{ $set: { s3Key } }]
+      }
+    }
+  })
+
+  const coll = /** @satisfies {Collection<FormFileUploadStatus>} */ (
+    db.collection(COLLECTION_NAME)
+  )
+
+  return coll.bulkWrite(ops, { session })
+}
+
+/**
  * Updates the retrievalKey for a given file ID.
  * @param {string[]} fileIds
  * @param {string} retrievalKey

--- a/src/api/files/repository.js
+++ b/src/api/files/repository.js
@@ -39,16 +39,6 @@ export async function getByFileId(fileId) {
 }
 
 /**
- * Updates the S3 Key for a given file ID.
- * @param {string} fileId
- * @param {string} s3Key
- * @param {ClientSession} session
- */
-export async function updateS3Key(fileId, s3Key, session) {
-  return updateField([fileId], 's3Key', s3Key, session)
-}
-
-/**
  * Updates the S3 Keys for a given set of files
  * @param {{ fileId: string; s3Bucket: string; oldS3Key: string; newS3Key: string; }[]} updateFiles
  * @param {ClientSession} session

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -117,14 +117,14 @@ export async function persistFiles(files, persistedRetrievalKey) {
   let updateFiles = []
 
   try {
+    updateFiles = files.map(({ fileId, initiatedRetrievalKey }) =>
+      copyS3File(fileId, initiatedRetrievalKey, client)
+    )
+
+    const res = await Promise.all(updateFiles)
+
     await session.withTransaction(async () => {
       logger.info(`Persisting ${files.length} files`)
-
-      updateFiles = files.map(({ fileId, initiatedRetrievalKey }) =>
-        copyS3File(fileId, initiatedRetrievalKey, client)
-      )
-
-      const res = await Promise.all(updateFiles)
 
       await repository.updateS3Keys(res, session)
 

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -124,10 +124,9 @@ export async function persistFiles(files, persistedRetrievalKey) {
         copyS3File(fileId, initiatedRetrievalKey, client)
       )
 
-      for await (const { fileId, newS3Key } of updateFiles) {
-        // Mongo doesn't support parallel transactions, so we have to await each one
-        await repository.updateS3Key(fileId, newS3Key, session)
-      }
+      const res = await Promise.all(updateFiles)
+
+      await repository.updateS3Keys(res, session)
 
       // Once we know the files have copied successfully, we can update the database
       const persistedRetrievalKeyHashed = await argon2.hash(

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -12,8 +12,7 @@ import Boom from '@hapi/boom'
 import argon2 from 'argon2'
 import { MongoServerError } from 'mongodb'
 
-import * as repository from './repository.js'
-
+import * as repository from '~/src/api/files/repository.js'
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/helpers/logging/logger.js'
 import { client as mongoClient } from '~/src/mongo.js'

--- a/src/api/files/service.test.js
+++ b/src/api/files/service.test.js
@@ -329,9 +329,13 @@ describe('Files service', () => {
         expect.any(Object) // the session which we aren't testing
       )
 
-      expect(repository.updateS3Key).toHaveBeenCalledWith(
-        successfulFile.fileId,
-        expectedNewKey,
+      expect(repository.updateS3Keys).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            fileId: successfulFile.fileId,
+            newS3Key: expectedNewKey
+          })
+        ]),
         expect.any(Object) // the session which we aren't testing
       )
 
@@ -340,12 +344,6 @@ describe('Files service', () => {
         Key: expectedNewKey,
         CopySource: 'dummy-bucket/staging/dummy-file-123.txt'
       })
-
-      expect(repository.updateS3Key).toHaveBeenCalledWith(
-        successfulFile.fileId,
-        expectedNewKey,
-        expect.any(Object) // the session which we aren't testing
-      )
 
       expect(s3Mock).toHaveReceivedCommandWith(DeleteObjectCommand, {
         Bucket: successfulFile.s3Bucket,
@@ -476,9 +474,13 @@ describe('Files service', () => {
           'dummy-bucket/staging/extra-level/extra-level-two/dummy-file-123.txt'
       })
 
-      expect(repository.updateS3Key).toHaveBeenCalledWith(
-        successfulFile.fileId,
-        expectedNewKey,
+      expect(repository.updateS3Keys).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            fileId: successfulFile.fileId,
+            newS3Key: expectedNewKey
+          })
+        ]),
         expect.any(Object) // the session which we aren't testing
       )
 


### PR DESCRIPTION
RE: https://github.com/DEFRA/forms-submission-api/pull/37 and the chat [here in Slack](https://defra-digital-team.slack.com/archives/C071FRPN9TK/p1724238845591149)

I kept this refactor out of pull 37 as I wanted to get the `persist` capability deployed ASAP. I'd like to discuss this approach when we're next all available though - seems cleaner and less chatty to use `bulkWrite`.

- should we consider [bulkWrite](https://github.com/DEFRA/forms-submission-api/pull/48/files#diff-c1cfd29d6aca6b89bba4f2051dd3d4b5e392c62e347830d26bf09099d2b6291aR70) rather than do the updates individually in a loop?
- These [two](https://github.com/DEFRA/forms-submission-api/blob/main/src/api/files/service.js#L179) `await`s also need addressing
- More exception handling/logging needed e.g what to do if [this](https://github.com/DEFRA/forms-submission-api/blob/main/src/api/files/service.js#L149C5-L149C58) fails, also on that line `updateFiles` is in an unknown state.

