### PR TITLE
feature/307615 ingest changes

### DIFF
--- a/src/api/types.js
+++ b/src/api/types.js
@@ -18,11 +18,11 @@
  * @typedef {object} FileUploadStatus
  * @property {string} fileId - uuid of the file
  * @property {string} filename - filename of file uploaded, if present
- * @property {string} contentType - The mime type as declared in the multipart upload
+ * @property {string} [contentType] - The mime type as declared in the multipart upload
  * @property {('complete'|'rejected'|'pending')} fileStatus - complete or rejected if the virus scan has completed, pending if its still in progress
  * @property {number} contentLength - Size of file in bytes
- * @property {string} checksumSha256 - SHA256 check sum of file recieved by cdp-uploader before uploading to S3 bucket
- * @property {string} detectedContentType - The mime type as detected by the CDP-Uploader
+ * @property {string} [checksumSha256] - SHA256 check sum of file recieved by cdp-uploader before uploading to S3 bucket
+ * @property {string} [detectedContentType] - The mime type as detected by the CDP-Uploader
  * @property {string} [s3Key] - S3 bucket where scanned file is moved. Only set if file status is complete
  * @property {string} [s3Bucket] - S3 Path where scanned file is moved. Includes path prefix if set. Only set when fileStatus is complete
  * @property {boolean} [hasError] - true/false Only set to true if the file has been rejected or could not be delivered. Reason is supplied in errorMessage field.

--- a/src/models/files.js
+++ b/src/models/files.js
@@ -4,11 +4,11 @@ const fileUploadStatusSchema = Joi.object()
   .keys({
     fileId: Joi.string().required(),
     filename: Joi.string().required(),
-    contentType: Joi.string().required(),
+    contentType: Joi.string().optional(),
     fileStatus: Joi.string().valid('complete').required(),
     contentLength: Joi.number().required(),
-    checksumSha256: Joi.string().required(),
-    detectedContentType: Joi.string().required(),
+    checksumSha256: Joi.string().optional(),
+    detectedContentType: Joi.string().optional(),
     s3Key: Joi.string().required(),
     s3Bucket: Joi.string().required(),
     hasError: Joi.boolean().optional(),
@@ -17,7 +17,7 @@ const fileUploadStatusSchema = Joi.object()
   .required()
   .unknown(true)
 
-// below wse use .unknown(true) as extras don't need to be a show stopper
+// below we use .unknown(true) as extras don't need to be a show stopper
 // just validate the bits we care about and let everything else through
 export const fileIngestPayloadSchema = Joi.object()
   .keys({

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -1,18 +1,17 @@
 import routes from '~/src/routes/index.js'
 
 /**
- * @satisfies {ServerRegisterPluginObject}
+ * @satisfies {ServerRegisterPluginObject<void>}
  */
 export const router = {
   plugin: {
     name: 'router',
     register(server) {
-      server.route(routes)
+      server.route(/** @type {ServerRoute[]} */ (routes))
     }
   }
 }
 
 /**
- * @template {object | void} [PluginOptions=void]
- * @typedef {import('@hapi/hapi').ServerRegisterPluginObject<PluginOptions>} ServerRegisterPluginObject
+ * @import { ServerRegisterPluginObject, ServerRoute } from '@hapi/hapi'
  */

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -42,10 +42,7 @@ export default [
          * @param {Error} err
          */
         failAction: (request, h, err) => {
-          request.logger.info(
-            'Ingestion failed validation, returning 200 OK',
-            err
-          )
+          request.logger.info('Ingestion failed, returning 200 OK', err)
 
           return h
             .response({ message: 'Ingestion failed' })

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -11,10 +11,10 @@ import {
   filePersistPayloadSchema
 } from '~/src/models/files.js'
 
-/**
- * @type {ServerRoute[]}
- */
 export default [
+  /**
+   * @satisfies {ServerRoute<{ Payload: RequestFileCreate }>}
+   */
   {
     method: 'POST',
     path: '/file',
@@ -33,11 +33,33 @@ export default [
     options: {
       auth: false,
       validate: {
-        payload: fileIngestPayloadSchema
+        payload: fileIngestPayloadSchema,
+        /**
+         * If the callback POST from CDP fails payload validation,
+         * we log the errors and return 200 OK to stop them retrying
+         * @param {RequestFileCreate} request
+         * @param {ResponseToolkit} h
+         * @param {Error} err
+         */
+        failAction: (request, h, err) => {
+          request.logger.info(
+            'Ingestion failed validation, returning 200 OK',
+            err
+          )
+
+          return h
+            .response({ message: 'Ingestion failed' })
+            .code(200)
+            .takeover()
+        }
       }
     }
   },
-  {
+
+  /**
+   * @satisfies {ServerRoute}
+   */
+  ({
     method: 'GET',
     path: '/file/{fileId}',
     /**
@@ -58,8 +80,12 @@ export default [
         params: fileRetrievalParamsSchema
       }
     }
-  },
-  {
+  }),
+
+  /**
+   * @satisfies {ServerRoute}
+   */
+  ({
     method: 'POST',
     path: '/file/link',
     /**
@@ -80,8 +106,12 @@ export default [
         payload: fileAccessPayloadSchema
       }
     }
-  },
-  {
+  }),
+
+  /**
+   * @satisfies {ServerRoute}
+   */
+  ({
     method: 'POST',
     path: '/files/persist',
     /**
@@ -103,10 +133,10 @@ export default [
         payload: filePersistPayloadSchema
       }
     }
-  }
+  })
 ]
 
 /**
- * @import { ServerRoute } from '@hapi/hapi'
+ * @import { ResponseToolkit, ServerRoute } from '@hapi/hapi'
  * @import { RequestFileCreate, RequestFileGet, RequestFileLinkCreate, RequestFilePersist } from '~/src/api/types.js'
  */

--- a/src/routes/files.test.js
+++ b/src/routes/files.test.js
@@ -149,10 +149,9 @@ describe('Forms route', () => {
         }
       })
 
-      expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
+      expect(response.statusCode).toEqual(StatusCodes.OK)
       expect(response.result).toMatchObject({
-        error: 'Bad Request',
-        message: '"form.file.fileStatus" must be [complete]'
+        message: 'Ingestion failed'
       })
     })
 
@@ -172,10 +171,9 @@ describe('Forms route', () => {
         }
       })
 
-      expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
+      expect(response.statusCode).toEqual(StatusCodes.OK)
       expect(response.result).toMatchObject({
-        error: 'Bad Request',
-        message: '"form.file" must be of type object'
+        message: 'Ingestion failed'
       })
     })
 
@@ -193,10 +191,9 @@ describe('Forms route', () => {
         }
       })
 
-      expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST)
+      expect(response.statusCode).toEqual(StatusCodes.OK)
       expect(response.result).toMatchObject({
-        error: 'Bad Request',
-        message: '"metadata.retrievalKey" is required'
+        message: 'Ingestion failed'
       })
     })
 


### PR DESCRIPTION
1. Loosen validation around contentType, checksumSha256 and detectedContentType fields
2. Change ingest file endpoint to return 200 OK in the event of payload validation failure