### PR TITLE
Replace logging preferred_username with oid and remove an error log

### DIFF
--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -57,7 +57,7 @@ export async function ingestFile(uploadPayload) {
  * Confirms a file exists in S3 by throwing Boom.badRequest if not.
  * @param {FileUploadStatus} fileUploadStatus
  * @param {Error} errorToThrow
- * @param {boolean} logAsError - whether to log the error
+ * @param {boolean} [logAsError] - whether to log the error
  */
 async function assertFileExists(
   fileUploadStatus,

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -57,8 +57,13 @@ export async function ingestFile(uploadPayload) {
  * Confirms a file exists in S3 by throwing Boom.badRequest if not.
  * @param {FileUploadStatus} fileUploadStatus
  * @param {Error} errorToThrow
+ * @param {boolean} logAsError - whether to log the error
  */
-async function assertFileExists(fileUploadStatus, errorToThrow) {
+async function assertFileExists(
+  fileUploadStatus,
+  errorToThrow,
+  logAsError = true
+) {
   try {
     const client = getS3Client()
 
@@ -70,10 +75,11 @@ async function assertFileExists(fileUploadStatus, errorToThrow) {
     await client.send(command)
   } catch (err) {
     if (err instanceof NotFound) {
-      logger.error(
+      logger[logAsError ? 'error' : 'info'](
         err,
-        `Recieved request to ingest ${fileUploadStatus.s3Key}, but the file does not exist.`
+        `Recieved request for ${fileUploadStatus.s3Key}, but the file does not exist.`
       )
+
       throw errorToThrow
     }
 
@@ -283,7 +289,7 @@ export async function checkFileStatus(fileId) {
     throw Boom.notFound()
   }
 
-  await assertFileExists(fileStatus, Boom.resourceGone())
+  await assertFileExists(fileStatus, Boom.resourceGone(), false)
 }
 
 /**

--- a/src/api/files/service.js
+++ b/src/api/files/service.js
@@ -77,7 +77,7 @@ async function assertFileExists(
     if (err instanceof NotFound) {
       logger[logAsError ? 'error' : 'info'](
         err,
-        `Recieved request for ${fileUploadStatus.s3Key}, but the file does not exist.`
+        `Received request for ${fileUploadStatus.s3Key}, but the file does not exist.`
       )
 
       throw errorToThrow

--- a/src/plugins/auth/index.js
+++ b/src/plugins/auth/index.js
@@ -30,7 +30,7 @@ export const auth = {
           exp: true
         },
         /**
-         * @param {Artifacts<UserProfile>} artifacts
+         * @param {Artifacts<UserCredentials>} artifacts
          */
         validate(artifacts) {
           const user = artifacts.decoded.payload
@@ -44,7 +44,7 @@ export const auth = {
 
           const { oid } = user
 
-          if (!oid || typeof oid !== 'string') {
+          if (!oid) {
             logger.error(
               'Authentication error: user.oid is not a string or is missing'
             )
@@ -69,7 +69,6 @@ export const auth = {
 }
 
 /**
- * @import { ServerRegisterPluginObject } from '@hapi/hapi'
- * @import { HapiJwt } from '@hapi/jwt'
- * @import { Artifacts, UserProfile } from '~/src/plugins/auth/types.js'
+ * @import { ServerRegisterPluginObject, UserCredentials } from '@hapi/hapi'
+ * @import { Artifacts } from '~/src/plugins/auth/types.js'
  */

--- a/src/plugins/auth/index.js
+++ b/src/plugins/auth/index.js
@@ -42,16 +42,18 @@ export const auth = {
             }
           }
 
-          const { preferred_username: preferredUsername } = user
+          const { oid } = user
 
-          if (!preferredUsername) {
-            logger.error('Authentication error: Missing preferred_username')
+          if (!oid || typeof oid !== 'string') {
+            logger.error(
+              'Authentication error: user.oid is not a string or is missing'
+            )
             return {
               isValid: false
             }
           }
 
-          logger.debug(`User ${preferredUsername}: passed authentication`)
+          logger.debug(`User ${oid}: passed authentication`)
 
           return {
             isValid: true,

--- a/src/plugins/auth/types.js
+++ b/src/plugins/auth/types.js
@@ -7,7 +7,3 @@
  * @template {object} Payload
  * @typedef {HapiJwt.Artifacts<{ JwtPayload?: Payload }>} Artifacts
  */
-
-/**
- * @typedef {IdTokenClaims & { groups?: string[] }} UserProfile
- */

--- a/src/plugins/log-requests.js
+++ b/src/plugins/log-requests.js
@@ -19,7 +19,7 @@ export const logRequests = {
       if (isAuthenticated && credentials.user) {
         const { user } = credentials
 
-        if ('oid' in user && typeof user.oid === 'string') {
+        if (user.oid) {
           userPrefix = ` [${user.oid}] `
         }
       }

--- a/src/plugins/log-requests.js
+++ b/src/plugins/log-requests.js
@@ -19,11 +19,8 @@ export const logRequests = {
       if (isAuthenticated && credentials.user) {
         const { user } = credentials
 
-        if (
-          'preferred_username' in user &&
-          typeof user.preferred_username === 'string'
-        ) {
-          userPrefix = ` [${user.preferred_username}] `
+        if ('oid' in user && typeof user.oid === 'string') {
+          userPrefix = ` [${user.oid}] `
         }
       }
 

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -1,0 +1,15 @@
+import { UserCredentials } from '@hapi/hapi'
+
+declare module '@hapi/hapi' {
+  interface UserCredentials {
+    /**
+     * Object ID of the user
+     */
+    oid?: string
+
+    /**
+     * Groups of the user
+     */
+    groups?: string[]
+  }
+}

--- a/test/fixtures/auth.js
+++ b/test/fixtures/auth.js
@@ -9,7 +9,8 @@ export const auth = {
       groups: ['7049296f-2156-4d61-8ac3-349276438ef9'],
       name: 'Enrique Chase (Defra)',
       scp: 'forms.user',
-      sub: 'hgtL_1p2Me5JkBB6JeB20PyU3YDuP9PjEZwi7m1QGng'
+      sub: 'hgtL_1p2Me5JkBB6JeB20PyU3YDuP9PjEZwi7m1QGng',
+      oid: '86758ba9-92e7-4287-9751-7705e449688e'
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": "./",
     "paths": {
       "~/*": ["./*"]
-    }
+    },
+    "typeRoots": ["./src/typings", "./node_modules/@types"]
   },
   "include": [
     "**/*.cjs",


### PR DESCRIPTION
- Drops `preferred_username` in the logs and instead uses `oid` as it's classed as non-PII in the log ingestion pipeline
- Querying an expired file isn't an error, so log it as info