### PR TITLE
Skip Slack posts for `dependabot/` branches

### DIFF
--- a/.github/workflows/pr-notifier.yml
+++ b/.github/workflows/pr-notifier.yml
@@ -46,7 +46,7 @@ jobs:
   notify:
     name: Slack notify
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ !contains(github.ref, 'dependabot/') }}
 
     steps:
       - name: Build Slack JSON


### PR DESCRIPTION
This PR follows up https://github.com/DEFRA/forms-designer/pull/522 to silence all Slack activity on `dependabot/` branches

Not just events from the Dependabot `github.actor`