### PR TITLE
Add manual publish via `workflow_dispatch`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ on:
       - 'src/**'
       - '!**/*.test.*'
 
+  workflow_dispatch:
+
 concurrency:
   group: publish
 


### PR DESCRIPTION
Adds manual "Run workflow" feature already added to:

* https://github.com/DEFRA/forms-manager/pull/340
* https://github.com/DEFRA/forms-designer/pull/585
* https://github.com/DEFRA/forms-runner/pull/455

All forms repos can now manually publish (if necessary) without requiring source code changes