### PR TITLE
Adds BOM code and utf8 encoding to solve strange chars in CSV

### DIFF
--- a/src/services/file-service.test.js
+++ b/src/services/file-service.test.js
@@ -985,21 +985,30 @@ describe('Files service', () => {
       expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
         Bucket: expect.anything(),
         Key: expect.anything(),
-        Body: 'Do you have any food allergies?,Telephone number field\nPeanuts,07800 100200\n',
+        // stringContaining so BOM code can be ignored in string comparison
+        Body: expect.stringContaining(
+          'Do you have any food allergies?,Telephone number field\nPeanuts,07800 100200\n'
+        ),
         ContentType: 'text/csv'
       })
 
       expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
         Bucket: expect.anything(),
         Key: expect.anything(),
-        Body: 'Select a drink,Toppings,Quantity\nCoke,Pepperoni,2\nFanta,Ham,3\n',
+        // stringContaining so BOM code can be ignored in string comparison
+        Body: expect.stringContaining(
+          'Select a drink,Toppings,Quantity\nCoke,Pepperoni,2\nFanta,Ham,3\n'
+        ),
         ContentType: 'text/csv'
       })
 
       expect(s3Mock).toHaveReceivedCommandWith(PutObjectCommand, {
         Bucket: expect.anything(),
         Key: expect.anything(),
-        Body: 'Name,Age of pet,Address,Favourite drink\nSooty,1,"1 Home Street, Ashford, AB10 1AB","Coke, Fanta"\n',
+        // stringContaining so BOM code can be ignored in string comparison
+        Body: expect.stringContaining(
+          'Name,Age of pet,Address,Favourite drink\nSooty,1,"1 Home Street, Ashford, AB10 1AB","Coke, Fanta"\n'
+        ),
         ContentType: 'text/csv'
       })
 

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -14,13 +14,14 @@ export function createCsv(input) {
   return new Promise((resolve, reject) => {
     stringify(
       input,
+      { bom: true },
       /** @type {Callback} */ function (err, output) {
         if (err) {
           reject(err instanceof Error ? err : new Error('CSV stringify error'))
           return
         }
 
-        resolve(output)
+        resolve(Buffer.from(output, 'utf8').toString())
       }
     )
   })


### PR DESCRIPTION
Ticket [DF-404](https://eaflood.atlassian.net/browse/DF-404)

Strange characters were appearing the imported CSV files due to encoding issues.

This solution seems to work ok on both Windows and Mac machines when opening the CSVs in Excel.
