### PR TITLE
fix(DF-922): remove unused versionNumber from FormModel constructor

### DIFF
--- a/src/services/submission-service.js
+++ b/src/services/submission-service.js
@@ -186,8 +186,7 @@ export async function getFormModelFromDb(formId, versionNumber, formStatus) {
     : await getFormDefinition(formId, formStatus)
 
   return new FormModel(replaceCustomControllers(formDefinition), {
-    basePath: '',
-    versionNumber
+    basePath: ''
   })
 }
 


### PR DESCRIPTION
The `versionNumber` option on `FormModel` only fed the now-removed `submittedVersionNumber` fallback path in the engine-plugin.