### PR TITLE
fix/df-995: Delete DLQ message by id

### DIFF
--- a/src/api/types.js
+++ b/src/api/types.js
@@ -65,7 +65,7 @@
  */
 
 /**
- * @typedef {{ Params: { dlq: string, messageId: string }, Payload: { receiptHandle: string }}} DeadLetterQueueAndHandleRequest
+ * @typedef {{ Params: { dlq: string, messageId: string }}} DeadLetterQueueAndHandleRequest
  */
 
 /**

--- a/src/messaging/event.js
+++ b/src/messaging/event.js
@@ -5,12 +5,15 @@ import {
 } from '@aws-sdk/client-sqs'
 
 import { config } from '~/src/config/index.js'
+import { createLogger } from '~/src/helpers/logging/logger.js'
 import { sqsClient } from '~/src/tasks/sqs.js'
 
 export const receiveMessageTimeout = config.get('receiveMessageTimeout')
 
 const maxNumberOfMessages = config.get('maxNumberOfMessages')
 const visibilityTimeout = config.get('visibilityTimeout')
+
+const logger = createLogger()
 
 /**
  * @param {string} dlqName
@@ -73,18 +76,43 @@ export function redriveDlqMessages(dlq) {
 }
 
 /**
- * Delete the specified message from the dead-letter queue
+ * Delete DLQ message by messageId
+ * This has to be done as a combined 'read then delete' (while using a visibility timeout of non-zero)
+ * otherwise the receipt handles become stale and the delete operation doesn't work.
  * @param {string} dlq - the SQS deadletter queue ARN
- * @param {string} receiptHandle - the message receipt handle (not the same as the message id)
- * @returns {Promise<DeleteMessageCommandOutput>}
+ * @param {string} messageId
  */
-export function deleteDlqMessage(dlq, receiptHandle) {
+export async function deleteDlqMessage(dlq, messageId) {
   const queueUrl = getDeadLetterQueueUrl(dlq)
-  const command = new DeleteMessageCommand({
+  const receiveCommand = new ReceiveMessageCommand({
     QueueUrl: queueUrl,
-    ReceiptHandle: receiptHandle
+    MaxNumberOfMessages: 10,
+    VisibilityTimeout: 2,
+    WaitTimeSeconds: 0
   })
-  return sqsClient.send(command)
+  const messageResponse = await sqsClient.send(receiveCommand)
+
+  const messages = messageResponse.Messages
+    ? messageResponse.Messages.filter((m) => m.MessageId === messageId)
+    : undefined
+  if (!messages?.length) {
+    const errorText = `Message with id ${messageId} not found in submissions-api (${dlq}) DLQ`
+    logger.info(errorText)
+    throw new Error(errorText)
+  }
+
+  logger.info(
+    `[DLQ] Number of messages found with id ${messageId}: ${messages.length}`
+  )
+  for (const message of messages) {
+    const deleteCommand = new DeleteMessageCommand({
+      QueueUrl: queueUrl,
+      ReceiptHandle: message.ReceiptHandle
+    })
+    logger.info(`[DLQ] Deleting message with id ${messageId}`)
+    await sqsClient.send(deleteCommand)
+    logger.info(`[DLQ] Deleted message with id ${messageId}`)
+  }
 }
 
 /**

--- a/src/messaging/event.test.js
+++ b/src/messaging/event.test.js
@@ -15,8 +15,6 @@ import {
   redriveDlqMessages
 } from '~/src/messaging/event.js'
 
-jest.mock('~/src/helpers/logging/logger.js')
-
 describe('event', () => {
   const snsMock = mockClient(SQSClient)
   const queueUrl = 'http://example.com'
@@ -125,19 +123,35 @@ describe('event', () => {
 
   describe('deleteDlqMessage', () => {
     it('should delete event message', async () => {
-      /**
-       * @type {DeleteMessageCommandOutput}
-       */
-      const deleteResult = {
-        $metadata: {}
+      const receivedMessage = {
+        Messages: [messageStub, messageStub, messageStub]
       }
 
-      snsMock.on(DeleteMessageCommand).resolves(deleteResult)
-      await deleteDlqMessage('save-and-exit', messageStub.ReceiptHandle)
+      snsMock.on(ReceiveMessageCommand).resolves(receivedMessage)
+      await deleteDlqMessage('save-and-exit', messageStub.MessageId)
+      expect(snsMock).toHaveReceivedCommandWith(ReceiveMessageCommand, {
+        QueueUrl: expect.any(String),
+        MaxNumberOfMessages: 10,
+        VisibilityTimeout: 2,
+        WaitTimeSeconds: 0
+      })
       expect(snsMock).toHaveReceivedCommandWith(DeleteMessageCommand, {
         QueueUrl: expect.any(String),
         ReceiptHandle: receiptHandle
       })
+    })
+
+    it('should throw if message not found', async () => {
+      const receivedMessage = {
+        Messages: []
+      }
+
+      snsMock.on(ReceiveMessageCommand).resolves(receivedMessage)
+      await expect(() =>
+        deleteDlqMessage('save-and-exit', messageStub.MessageId)
+      ).rejects.toThrow(
+        'Message with id 31cb6fff-8317-412e-8488-308d099034c4 not found in submissions-api (save-and-exit) DLQ'
+      )
     })
   })
 })

--- a/src/models/form.js
+++ b/src/models/form.js
@@ -75,5 +75,3 @@ export const getSubmissionByReferenceResponseSchema = Joi.object()
 export const dqlSchema = Joi.string().valid('form-submissions', 'save-and-exit')
 
 export const messageIdSchema = Joi.string()
-
-export const receiptHandleSchema = Joi.string()

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -13,7 +13,6 @@ import {
   generateFormSubmissionsFileResponseSchema,
   magicLinkSchema,
   messageIdSchema,
-  receiptHandleSchema,
   resetSaveAndExitLinkResponseSchema
 } from '~/src/models/form.js'
 import { resetSaveAndExitLink } from '~/src/services/save-and-exit-service.js'
@@ -226,11 +225,10 @@ export default [
     method: 'DELETE',
     path: '/admin/deadletter/{dlq}/{messageId}',
     async handler(request, h) {
-      const { params, payload } = request
+      const { params } = request
       const { dlq, messageId } = params
-      const { receiptHandle } = payload
       logger.info(`Deleting DLQ message ${messageId} on ${dlq}`)
-      await deleteDlqMessage(dlq, receiptHandle)
+      await deleteDlqMessage(dlq, messageId)
       logger.info(`Deleted DLQ message ${messageId} on ${dlq}`)
       return h.response({ message: 'success' }).code(OK_RESPONSE)
     },
@@ -245,12 +243,7 @@ export default [
             dlq: dqlSchema.required(),
             messageId: messageIdSchema.required()
           })
-          .label('deadLetterDeleteMessageParams'),
-        payload: Joi.object()
-          .keys({
-            receiptHandle: receiptHandleSchema.required()
-          })
-          .label('deadLetterDeleteMessagePayload')
+          .label('deadLetterDeleteMessageParams')
       }
     }
   })

--- a/src/routes/admin.test.js
+++ b/src/routes/admin.test.js
@@ -258,10 +258,7 @@ describe('Admin route', () => {
       const response = await server.inject({
         method: 'DELETE',
         url: '/admin/deadletter/save-and-exit/message-id',
-        auth: authSuperadmin,
-        payload: {
-          receiptHandle: 'receipt-handle'
-        }
+        auth: authSuperadmin
       })
 
       expect(response.statusCode).toEqual(okStatusCode)
@@ -269,7 +266,7 @@ describe('Admin route', () => {
       expect(response.result).toEqual({ message: 'success' })
       expect(deleteDlqMessage).toHaveBeenCalledWith(
         'save-and-exit',
-        'receipt-handle'
+        'message-id'
       )
     })
 
@@ -277,10 +274,7 @@ describe('Admin route', () => {
       const response = await server.inject({
         method: 'DELETE',
         url: '/admin/deadletter/form-submissions/message-id',
-        auth: authSuperadmin,
-        payload: {
-          receiptHandle: 'receipt-handle'
-        }
+        auth: authSuperadmin
       })
 
       expect(response.statusCode).toEqual(okStatusCode)
@@ -288,7 +282,7 @@ describe('Admin route', () => {
       expect(response.result).toEqual({ message: 'success' })
       expect(deleteDlqMessage).toHaveBeenCalledWith(
         'form-submissions',
-        'receipt-handle'
+        'message-id'
       )
     })
   })


### PR DESCRIPTION
Delete DLQ message by id.
Due to potentially stake receipt handles, deleting a DLQ message is now performed by do a 'read' (with VisibiltyTimeout of non-zero), then immediately doing the 'delete' while the VisibilityTimeout is still blocking other clients viewing the messages.