### PR TITLE
Allow GET submission route to be called by AD only authenticated users

### DIFF
--- a/src/routes/submission.js
+++ b/src/routes/submission.js
@@ -1,4 +1,3 @@
-import { Scopes } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import Joi from 'joi'
 
@@ -29,7 +28,10 @@ export default [
     options: {
       tags: ['api'],
       auth: {
-        scope: [`+${Scopes.FormRead}`]
+        access: {
+          entity: 'user',
+          scope: false
+        }
       },
       validate: {
         params: Joi.object()

--- a/src/routes/submission.test.js
+++ b/src/routes/submission.test.js
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { createServer } from '~/src/api/server.js'
 import { STUB_SUBMISSION_REF } from '~/src/repositories/__stubs__/submission.js'
 import { getSubmissionRecordByReference } from '~/src/repositories/submission-repository.js'
-import { authAdmin } from '~/test/fixtures/auth.js'
+import { authAD, authAdmin } from '~/test/fixtures/auth.js'
 // @ts-expect-error - import json
 import formSubmissions from '~/test/fixtures/forms-submissions.json'
 
@@ -50,6 +50,22 @@ describe('Submission routes', () => {
       })
 
       expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND)
+    })
+
+    test('Testing GET /submission/{referenceNumber} route is successful with AD-only auth', async () => {
+      const expectedRecord = formSubmissions.at(0)
+      jest
+        .mocked(getSubmissionRecordByReference)
+        // @ts-expect-error - test data is not fully compliant with FormSubmissionDocument type
+        .mockResolvedValue(expectedRecord)
+
+      const response = await server.inject({
+        method: 'GET',
+        url: `/submission/${STUB_SUBMISSION_REF}`,
+        auth: authAD
+      })
+
+      expect(response.statusCode).toEqual(StatusCodes.OK)
     })
   })
 })

--- a/test/fixtures/auth.js
+++ b/test/fixtures/auth.js
@@ -71,7 +71,7 @@ export const authAD = {
       given_name: 'Enrique',
       groups: ['7049296f-2156-4d61-8ac3-349276438ef9'],
       name: 'Enrique Chase (Defra)',
-      scp: 'forms.user',
+      scp: '',
       sub: 'hgtL_1p2Me5JkBB6JeB20PyU3YDuP9PjEZwi7m1QGng',
       oid: '86758ba9-92e7-4287-9751-7705e449688e',
       roles: []

--- a/test/fixtures/auth.js
+++ b/test/fixtures/auth.js
@@ -61,6 +61,25 @@ export const authAdmin = {
   }
 }
 
+export const authAD = {
+  strategy: 'azure-oidc-token',
+  credentials: {
+    user: {
+      aud: 'api://2bf2d9fd-fe1e-47eb-9821-b6f6cd3ceba1',
+      iss: 'https://sts.windows.net/5b504113-6b64-43f2-ade9-242e05780008/',
+      family_name: 'Chase',
+      given_name: 'Enrique',
+      groups: ['7049296f-2156-4d61-8ac3-349276438ef9'],
+      name: 'Enrique Chase (Defra)',
+      scp: 'forms.user',
+      sub: 'hgtL_1p2Me5JkBB6JeB20PyU3YDuP9PjEZwi7m1QGng',
+      oid: '86758ba9-92e7-4287-9751-7705e449688e',
+      roles: []
+    },
+    scope: []
+  }
+}
+
 export const appAuth = {
   strategy: 'cognito-access-token',
   credentials: {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DF-1041

Map submissions view in FD currently requires the user to be logged in with an FD account.

This change fixes that so anyone with an AD account can see the page.

