### PR TITLE
Download Prod Forms Issue with Wrong Versions

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -1,0 +1,48 @@
+name: Publish Hot Fix
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+env:
+  AWS_REGION: eu-west-2
+  AWS_ACCOUNT_ID: '094954420758'
+
+jobs:
+  build:
+    name: CDP-build-hotfix-workflow
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Depth 0 is required for branch-based versioning
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Test code and Create Test Coverage Reports
+        run: |
+          npm ci
+          npm run build
+          npm run format:check
+          npm run lint
+          npm test
+
+      - name: Publish Hot Fix
+        uses: DEFRA/cdp-build-action/build-hotfix@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/src/services/submission-service.js
+++ b/src/services/submission-service.js
@@ -4,6 +4,7 @@ import {
   hasRepeater,
   replaceCustomControllers
 } from '@defra/forms-model'
+import Boom from '@hapi/boom'
 import argon2 from 'argon2'
 import xlsx from 'xlsx'
 
@@ -319,14 +320,37 @@ export async function lookupFormNameById(context, formId) {
  */
 export async function getFormModel(context, formId, versionNumber, formStatus) {
   const { models } = context.caches
+  const nonExistentVersionNumber = -(versionNumber ?? 0)
+
   if (models.has(versionNumber)) {
     return models.get(versionNumber)
-  } else {
-    const formModel = await getFormModelFromDb(
-      formId,
-      versionNumber,
-      formStatus
+  } else if (models.has(nonExistentVersionNumber)) {
+    // We want to be able to count in logs how many submissions are affected by this issue
+    // and this special case allows us to do that.
+    logger.warn(
+      `Form version ${versionNumber} was not found for form ID ${formId}. Will use cached latest version instead`
     )
+    return models.get(nonExistentVersionNumber)
+  } else {
+    let formModel
+    try {
+      formModel = await getFormModelFromDb(formId, versionNumber, formStatus)
+    } catch (err) {
+      if (!Boom.isBoom(err) || err.output.statusCode !== 404) {
+        throw err
+      }
+
+      // Normally, this should never happen. However, there has been a bug whereby submissions have
+      // ended up with an incorrect version. This path guards against that.
+      logger.warn(
+        `Form version ${versionNumber} was not found for form ID ${formId}. Will use latest version instead`
+      )
+
+      // Get the latest version and use that in place of the non-existent version, but
+      // cache it in a way that we can identify it as such.
+      formModel = await getFormModelFromDb(formId, undefined, formStatus)
+      versionNumber = nonExistentVersionNumber
+    }
 
     models.set(versionNumber, formModel)
 

--- a/src/services/submission-service.js
+++ b/src/services/submission-service.js
@@ -326,6 +326,10 @@ export async function getFormModel(context, formId, versionNumber, formStatus) {
   if (models.has(versionNumber)) {
     return models.get(versionNumber)
   } else if (models.has(nonExistentVersionNumber)) {
+    // This path is a special case where:
+    // - This function has been called previously for this versionNumber and entered the catch block below
+    // - The form version requested does not exist
+    // - We've cached the latest version for this version number using the non-existent version (ie the negative version number)
     // We want to be able to count in logs how many submissions are affected by this issue
     // and this special case allows us to do that.
     logger.warn(

--- a/src/services/submission-service.js
+++ b/src/services/submission-service.js
@@ -6,6 +6,7 @@ import {
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import argon2 from 'argon2'
+import { StatusCodes } from 'http-status-codes'
 import xlsx from 'xlsx'
 
 import { config } from '~/src/config/index.js'
@@ -336,7 +337,7 @@ export async function getFormModel(context, formId, versionNumber, formStatus) {
     try {
       formModel = await getFormModelFromDb(formId, versionNumber, formStatus)
     } catch (err) {
-      if (!Boom.isBoom(err) || err.output.statusCode !== 404) {
+      if (!Boom.isBoom(err, StatusCodes.NOT_FOUND)) {
         throw err
       }
 

--- a/src/services/submission-service.test.js
+++ b/src/services/submission-service.test.js
@@ -1,6 +1,9 @@
+import { FormStatus } from '@defra/forms-engine-plugin/types'
 import { ComponentType } from '@defra/forms-model'
+import Boom from '@hapi/boom'
 import xlsx from 'xlsx'
 
+import { logger } from '~/src/helpers/logging/logger.js'
 import { getSubmissionRecords } from '~/src/repositories/submission-repository.js'
 import {
   getFormDefinition,
@@ -14,6 +17,7 @@ import {
   generateFeedbackSubmissionsFileForAll,
   generateFeedbackSubmissionsFileForForm,
   generateFormSubmissionsFile,
+  getFormModel,
   getMetadataFromForm,
   lookupFormNameById
 } from '~/src/services/submission-service.js'
@@ -36,7 +40,8 @@ jest.mock('~/src/helpers/logging/logger.js', () => ({
   logger: {
     error: jest.fn(),
     info: jest.fn(),
-    debug: jest.fn()
+    debug: jest.fn(),
+    warn: jest.fn()
   }
 }))
 
@@ -492,6 +497,125 @@ D44-841-706,28/11/2025,draft,Yes,Chocolate,kinder@egg.com,A,12345,"House name, F
       const res = await lookupFormNameById(mockContext, 'form-id')
       expect(res).toBe('form-name')
       expect(mockSet).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getFormModel', () => {
+    const formId = '688131eeff67f889d52c66cc'
+    const versionNumber = 36
+
+    /** @type {SpreadsheetContext} */
+    let mockContext
+
+    beforeEach(() => {
+      mockContext = {
+        // @ts-expect-error - not all context mocked
+        caches: {
+          models: new Map()
+        },
+        options: {}
+      }
+    })
+
+    test('should return model from cache when versionNumber is cached', async () => {
+      const cachedModel = /** @type {any} */ ({})
+      mockContext.caches.models.set(versionNumber, cachedModel)
+
+      const result = await getFormModel(
+        mockContext,
+        formId,
+        versionNumber,
+        FormStatus.Live
+      )
+
+      expect(result).toBe(cachedModel)
+      expect(getFormDefinitionVersion).not.toHaveBeenCalled()
+    })
+
+    test('should return cached fallback model and warn when nonExistentVersion key is cached', async () => {
+      const nonExistentVersion = -versionNumber
+      const cachedFallback = /** @type {any} */ ({})
+      mockContext.caches.models.set(nonExistentVersion, cachedFallback)
+
+      const result = await getFormModel(
+        mockContext,
+        formId,
+        versionNumber,
+        FormStatus.Live
+      )
+
+      expect(result).toBe(cachedFallback)
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Form version ${versionNumber} was not found for form ID ${formId}. Will use cached latest version instead`
+      )
+      expect(getFormDefinitionVersion).not.toHaveBeenCalled()
+    })
+
+    test('should fetch from DB, cache under versionNumber and return model', async () => {
+      const versions = /** @type {Record<string, FormDefinition>} */ (
+        /** @type {unknown} */ (formVersions)
+      )
+      jest
+        .mocked(getFormDefinitionVersion)
+        .mockResolvedValueOnce(versions['36'])
+
+      const result = await getFormModel(
+        mockContext,
+        formId,
+        versionNumber,
+        FormStatus.Live
+      )
+
+      expect(getFormDefinitionVersion).toHaveBeenCalledWith(
+        formId,
+        versionNumber
+      )
+      expect(result).toBeDefined()
+      expect(mockContext.caches.models.get(versionNumber)).toBe(result)
+    })
+
+    test('should fall back to latest version on DB 404, cache under nonExistentVersion key and warn', async () => {
+      const nonExistentVersion = -versionNumber
+      const versions = /** @type {Record<string, FormDefinition>} */ (
+        /** @type {unknown} */ (formVersions)
+      )
+      jest
+        .mocked(getFormDefinitionVersion)
+        .mockRejectedValueOnce(Boom.notFound())
+      jest.mocked(getFormDefinition).mockResolvedValueOnce(versions['36'])
+
+      const result = await getFormModel(
+        mockContext,
+        formId,
+        versionNumber,
+        FormStatus.Live
+      )
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        `Form version ${versionNumber} was not found for form ID ${formId}. Will use latest version instead`
+      )
+      expect(getFormDefinition).toHaveBeenCalledWith(formId, 'live')
+      expect(result).toBeDefined()
+      expect(mockContext.caches.models.get(nonExistentVersion)).toBe(result)
+      expect(mockContext.caches.models.has(versionNumber)).toBe(false)
+    })
+
+    test('should rethrow non-404 Boom errors', async () => {
+      const error = Boom.badRequest('Something went wrong')
+      jest.mocked(getFormDefinitionVersion).mockRejectedValueOnce(error)
+
+      await expect(
+        getFormModel(mockContext, formId, versionNumber, FormStatus.Live)
+      ).rejects.toBe(error)
+    })
+
+    test('should rethrow non-Boom errors', async () => {
+      const error = new Error('Database connection failed')
+      jest.mocked(getFormDefinitionVersion).mockRejectedValueOnce(error)
+
+      await expect(
+        getFormModel(mockContext, formId, versionNumber, FormStatus.Live)
+      ).rejects.toBe(error)
     })
   })
 })


### PR DESCRIPTION
Allows forms to be downloaded where the form submission data includes the incorrect form definition version (due to another bug which has since been resolved). What happens now when the form version cannot be found is:

- The latest form definition is used.
- A warning is logged that the requested form version could not be found.